### PR TITLE
Instance for ZonedTime

### DIFF
--- a/src/Data/Binary/Orphans.hs
+++ b/src/Data/Binary/Orphans.hs
@@ -159,6 +159,11 @@ instance Binary Time.LocalTime where
   get = liftM2 Time.LocalTime get get
   put (Time.LocalTime d tod) = put d >> put tod
 
+-- | /Since: binary-orphans-0.1.5.0/
+instance Binary Time.ZonedTime where
+  get = liftM2 Time.ZonedTime get get
+  put (Time.ZonedTime t z) = put t >> put z
+
 -- | /Since: binary-orphans-0.1.4.0/
 instance Binary Time.AbsoluteTime where
   get = fmap (flip Time.addAbsoluteTime Time.taiEpoch) get


### PR DESCRIPTION
Thanks for the useful package!  I noticed that there wasn't an instance for `ZonedTime` (but there were instances for `LocalTime` and `TimeZone`), so it seemed a bit straightforward to add it.  I added a haddock stub pre-emptively, guessing the next release version.  Let me know if there are any issues/problems that would come from this