### PR TITLE
Allow building with base-4.15.* and tasty-1.4.*

### DIFF
--- a/binary-orphans.cabal
+++ b/binary-orphans.cabal
@@ -39,7 +39,7 @@ library
   exposed-modules:  Data.Binary.Orphans
   other-extensions: CPP
   build-depends:
-      base          >=4.5     && <4.15
+      base          >=4.5     && <4.16
     , binary        >=0.5.1.0 && <0.6 || >=0.7.1.0 && <0.8 || >=0.8.3.0 && <0.8.9
     , transformers  >=0.3.0.0 && <0.7
 
@@ -64,7 +64,7 @@ test-suite binary-orphans-test
     , QuickCheck            >=2.13.1   && <2.15
     , quickcheck-instances  >=0.3.21   && <0.4
     , tagged                >=0.8.6    && <0.8.7
-    , tasty                 >=0.10.1.2 && <1.4
+    , tasty                 >=0.10.1.2 && <1.5
     , tasty-quickcheck      >=0.8.3.2  && <0.11
 
   if !impl(ghc >=8.0)


### PR DESCRIPTION
`base-4.15.*` is needed for GHC 9.0 support. `tasty-1.4.*` is the latest Hackage release, and based on [the changelog](http://hackage.haskell.org/package/tasty-1.4.1/changelog), none of the changes seem to apply to `binary-orphans`. I've verified that the test suite continues to pass with these new versions.