### PR TITLE
Use https instead of git:// for source url

### DIFF
--- a/binary-orphans.cabal
+++ b/binary-orphans.cabal
@@ -34,7 +34,7 @@ extra-source-files: CHANGELOG.md
 
 source-repository head
   type:     git
-  location: git://github.com/phadej/binary-orphans.git
+  location: https://github.com/phadej/binary-orphans.git
 
 library
   default-language: Haskell2010


### PR DESCRIPTION
`git://` is no longer supported.